### PR TITLE
test: add PR checks and baseline unit tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,48 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v2.1.0
+
+jobs:
+  pr-checks:
+    name: PR Checks
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "Outer Spaces.xcodeproj" \
+            -scheme "Outer Spaces"
+
+      - name: Build without signing
+        run: |
+          xcodebuild \
+            -project "Outer Spaces.xcodeproj" \
+            -scheme "Outer Spaces" \
+            -configuration Debug \
+            -derivedDataPath build/DerivedData \
+            -destination "platform=macOS,arch=$(uname -m)" \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Run unit tests
+        run: |
+          xcodebuild \
+            -project "Outer Spaces.xcodeproj" \
+            -scheme "Outer Spaces" \
+            -configuration Debug \
+            -derivedDataPath build/DerivedData \
+            -destination "platform=macOS,arch=$(uname -m)" \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            test

--- a/Outer Spaces Tests/ManagedDisplaySpacesParserTests.swift
+++ b/Outer Spaces Tests/ManagedDisplaySpacesParserTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import Outer_Spaces
+
+struct ManagedDisplaySpacesParserTests {
+    @Test("Parser creates spaces for one display and marks active space")
+    func parsesOneDisplayAndMarksActiveSpace() throws {
+        let snapshot = ManagedDisplaySpacesParser.parse([
+            display(
+                id: "main",
+                activeSpaceID: 102,
+                spaces: [
+                    regularSpace(id: 101),
+                    regularSpace(id: 102),
+                ]
+            ),
+        ])
+
+        #expect(snapshot.activeSpaceID == "102")
+        #expect(snapshot.desktopSpaces.count == 1)
+        #expect(snapshot.allSpaces.map(\.spaceID) == ["101", "102"])
+        #expect(snapshot.allSpaces.map(\.spaceIndex) == [0, 1])
+        #expect(snapshot.allSpaces.first(where: { $0.spaceID == "102" })?.isActive == true)
+    }
+
+    @Test("Parser skips fullscreen spaces and keeps regular indexes compact")
+    func skipsFullscreenSpacesAndKeepsIndexesCompact() {
+        let snapshot = ManagedDisplaySpacesParser.parse([
+            display(
+                id: "main",
+                activeSpaceID: 103,
+                spaces: [
+                    regularSpace(id: 101),
+                    fullscreenSpace(id: 102),
+                    regularSpace(id: 103),
+                ]
+            ),
+        ])
+
+        #expect(snapshot.allSpaces.map(\.spaceID) == ["101", "103"])
+        #expect(snapshot.allSpaces.map(\.spaceIndex) == [0, 1])
+    }
+
+    @Test("Parser uses one-based display indexes for multiple displays")
+    func parsesMultipleDisplaysWithOneBasedIndexes() {
+        let snapshot = ManagedDisplaySpacesParser.parse([
+            display(id: "main", activeSpaceID: 101, spaces: [regularSpace(id: 101)]),
+            display(id: "secondary", activeSpaceID: 201, spaces: [regularSpace(id: 201)]),
+        ])
+
+        #expect(snapshot.desktopSpaces.map(\.displayID) == ["main", "secondary"])
+        #expect(snapshot.desktopSpaces.map(\.displayIndex) == [1, 2])
+        #expect(snapshot.allSpaces.map(\.displayIndex) == [1, 2])
+    }
+
+    @Test("Parser ignores malformed display entries")
+    func ignoresMalformedDisplayEntries() {
+        let malformed = NSDictionary(dictionary: [
+            "Display Identifier": "broken",
+            "Spaces": [regularSpace(id: 1)],
+        ])
+
+        let snapshot = ManagedDisplaySpacesParser.parse([
+            display(id: "main", activeSpaceID: 101, spaces: [regularSpace(id: 101)]),
+            malformed,
+        ])
+
+        #expect(snapshot.desktopSpaces.count == 1)
+        #expect(snapshot.desktopSpaces.first?.displayID == "main")
+        #expect(snapshot.allSpaces.map(\.spaceID) == ["101"])
+    }
+
+    private func display(id: String, activeSpaceID: Int, spaces: [[String: Any]]) -> NSDictionary {
+        NSDictionary(dictionary: [
+            "Display Identifier": id,
+            "Current Space": ["ManagedSpaceID": activeSpaceID],
+            "Spaces": spaces,
+        ])
+    }
+
+    private func regularSpace(id: Int) -> [String: Any] {
+        [
+            "ManagedSpaceID": id,
+            "type": 0,
+        ]
+    }
+
+    private func fullscreenSpace(id: Int) -> [String: Any] {
+        [
+            "ManagedSpaceID": id,
+            "type": 4,
+        ]
+    }
+}

--- a/Outer Spaces Tests/ModelTests.swift
+++ b/Outer Spaces Tests/ModelTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import Outer_Spaces
+
+struct ModelTests {
+    @Test("Space sorts by display index, then space index")
+    func spaceSortsByDisplayThenSpaceIndex() {
+        let spaces = [
+            Space(displayID: "secondary", displayIndex: 2, spaceID: "3", spaceIndex: 0),
+            Space(displayID: "main", displayIndex: 1, spaceID: "2", spaceIndex: 1),
+            Space(displayID: "main", displayIndex: 1, spaceID: "1", spaceIndex: 0),
+        ]
+
+        #expect(spaces.sorted().map(\.spaceID) == ["1", "2", "3"])
+    }
+
+    @Test("Space codable round trip excludes active state")
+    func spaceCodableRoundTripExcludesActiveState() throws {
+        let original = Space(
+            displayID: "main",
+            displayIndex: 1,
+            spaceID: "10",
+            customName: "Writing",
+            spaceIndex: 0,
+            isActive: true
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Space.self, from: data)
+
+        #expect(decoded.displayID == original.displayID)
+        #expect(decoded.displayIndex == original.displayIndex)
+        #expect(decoded.spaceID == original.spaceID)
+        #expect(decoded.customName == original.customName)
+        #expect(decoded.spaceIndex == original.spaceIndex)
+        #expect(decoded.isActive == false)
+    }
+
+    @Test("DesktopSpaces sorts contained spaces by space index")
+    func desktopSpacesSortsContainedSpaces() {
+        let spaces = [
+            Space(displayID: "main", spaceID: "3", spaceIndex: 2),
+            Space(displayID: "main", spaceID: "1", spaceIndex: 0),
+            Space(displayID: "main", spaceID: "2", spaceIndex: 1),
+        ]
+
+        let desktopSpaces = DesktopSpaces(displayID: "main", displayIndex: 1, spaces: spaces)
+
+        #expect(desktopSpaces.desktopSpaces.map(\.spaceID) == ["1", "2", "3"])
+    }
+
+    @Test("Focus codable round trip preserves values")
+    func focusCodableRoundTripPreservesValues() throws {
+        let focusID = UUID()
+        let spaceID = UUID()
+        let focus = Focus(
+            id: focusID,
+            name: "Deep Work",
+            spaces: [
+                Space(
+                    id: spaceID,
+                    displayID: "main",
+                    displayIndex: 1,
+                    spaceID: "42",
+                    customName: "Editor",
+                    spaceIndex: 0,
+                    isActive: true
+                )
+            ],
+            stageManager: true
+        )
+
+        let data = try JSONEncoder().encode(focus)
+        let decoded = try JSONDecoder().decode(Focus.self, from: data)
+
+        #expect(decoded.id == focusID)
+        #expect(decoded.name == "Deep Work")
+        #expect(decoded.stageManager == true)
+        #expect(decoded.spaces.count == 1)
+        #expect(decoded.spaces.first?.id == spaceID)
+        #expect(decoded.spaces.first?.spaceID == "42")
+    }
+}

--- a/Outer Spaces Tests/SpaceSwitchCommandTests.swift
+++ b/Outer Spaces Tests/SpaceSwitchCommandTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Outer_Spaces
+
+struct SpaceSwitchCommandTests {
+    @Test("Space index zero maps to Control+1")
+    func zeroMapsToControlOne() throws {
+        let command = try SpaceSwitchCommandFactory.command(forSpaceIndex: 0)
+
+        #expect(command.keyCode == 18)
+        #expect(command.usesOptionKey == false)
+        #expect(command.appleScriptSource.contains("key code 18 using {control down}"))
+    }
+
+    @Test("Space index eight maps to Control+9")
+    func eightMapsToControlNine() throws {
+        let command = try SpaceSwitchCommandFactory.command(forSpaceIndex: 8)
+
+        #expect(command.keyCode == 25)
+        #expect(command.usesOptionKey == false)
+        #expect(command.appleScriptSource.contains("key code 25 using {control down}"))
+    }
+
+    @Test("Space indexes at nine and above use Option-modified shortcuts")
+    func indexesAtNineAndAboveUseOptionModifiedShortcuts() throws {
+        let command = try SpaceSwitchCommandFactory.command(forSpaceIndex: 9)
+
+        #expect(command.keyCode == 29)
+        #expect(command.usesOptionKey == true)
+        #expect(command.appleScriptSource.contains("key code 29 using {control down, option down}"))
+    }
+
+    @Test("Negative space indexes throw invalid index error")
+    func negativeIndexesThrowInvalidIndexError() {
+        do {
+            _ = try SpaceSwitchCommandFactory.command(forSpaceIndex: -2)
+            Issue.record("Expected a negative index to throw SpaceSwitchError.invalidSpaceIndex.")
+        } catch SpaceSwitchError.invalidSpaceIndex {
+            // Expected path.
+        } catch {
+            Issue.record("Unexpected error thrown: \(error)")
+        }
+    }
+}

--- a/Outer Spaces.xcodeproj/project.pbxproj
+++ b/Outer Spaces.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AABBA0012F100001000B6D85 /* ManagedDisplaySpacesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBA0022F100002000B6D85 /* ManagedDisplaySpacesParser.swift */; };
+		AABBA0032F100003000B6D85 /* SpaceSwitchCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBA0042F100004000B6D85 /* SpaceSwitchCommand.swift */; };
+		AABC00012F200001000B6D85 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABC00022F200002000B6D85 /* ModelTests.swift */; };
+		AABC00032F200003000B6D85 /* ManagedDisplaySpacesParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABC00042F200004000B6D85 /* ManagedDisplaySpacesParserTests.swift */; };
+		AABC00052F200005000B6D85 /* SpaceSwitchCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABC00062F200006000B6D85 /* SpaceSwitchCommandTests.swift */; };
 		0705A7912B5241D0005CA574 /* SpaceSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0705A7922B5241D0005CA574 /* SpaceSwitcher.swift */; };
 		0715DE512B0AAB1600A6E46C /* AppMenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0715DE502B0AAB1600A6E46C /* AppMenuBar.swift */; };
 		0715DE542B0AAC2700A6E46C /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = 0715DE532B0AAC2700A6E46C /* SFSafeSymbols */; };
@@ -66,6 +71,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AABBA0022F100002000B6D85 /* ManagedDisplaySpacesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedDisplaySpacesParser.swift; sourceTree = "<group>"; };
+		AABBA0042F100004000B6D85 /* SpaceSwitchCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitchCommand.swift; sourceTree = "<group>"; };
+		AABC00022F200002000B6D85 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
+		AABC00042F200004000B6D85 /* ManagedDisplaySpacesParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedDisplaySpacesParserTests.swift; sourceTree = "<group>"; };
+		AABC00062F200006000B6D85 /* SpaceSwitchCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitchCommandTests.swift; sourceTree = "<group>"; };
+		AABC00072F200007000B6D85 /* Outer Spaces Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Outer Spaces Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0705A7922B5241D0005CA574 /* SpaceSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSwitcher.swift; sourceTree = "<group>"; };
 		0715DE502B0AAB1600A6E46C /* AppMenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMenuBar.swift; sourceTree = "<group>"; };
 		073100792B674C9C00F3D630 /* UpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateView.swift; sourceTree = "<group>"; };
@@ -105,6 +116,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		AABC00082F200008000B6D85 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		07A6269D2B06C6480013FE80 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -123,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				0764C1042D90F1B2000B6D85 /* PermissionHandler.swift */,
+				AABBA0042F100004000B6D85 /* SpaceSwitchCommand.swift */,
 				0705A7922B5241D0005CA574 /* SpaceSwitcher.swift */,
 			);
 			path = Helper;
@@ -168,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				07A626A22B06C6480013FE80 /* Outer Spaces */,
+				AABC00102F200010000B6D85 /* Outer Spaces Tests */,
 				07A626A12B06C6480013FE80 /* Products */,
 				0731007D2B73F2AB00F3D630 /* Frameworks */,
 			);
@@ -177,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				07A626A02B06C6480013FE80 /* Outer Spaces.app */,
+				AABC00072F200007000B6D85 /* Outer Spaces Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -225,6 +246,7 @@
 			children = (
 				07417FF82B5F081D00B26423 /* SparkleUpdater */,
 				0705A78E2B5241C3005CA574 /* Helper */,
+				AABBA0022F100002000B6D85 /* ManagedDisplaySpacesParser.swift */,
 				07FEE3332B07B2EF00419E50 /* SpaceObserver.swift */,
 				AABB00012D000001000B6D85 /* Logger.swift */,
 				07CD7B922B06C8E400D39387 /* Focus */,
@@ -273,9 +295,49 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		AABC00102F200010000B6D85 /* Outer Spaces Tests */ = {
+			isa = PBXGroup;
+			children = (
+				AABC00022F200002000B6D85 /* ModelTests.swift */,
+				AABC00042F200004000B6D85 /* ManagedDisplaySpacesParserTests.swift */,
+				AABC00062F200006000B6D85 /* SpaceSwitchCommandTests.swift */,
+			);
+			path = "Outer Spaces Tests";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
+/* Begin PBXContainerItemProxy section */
+		AABC00112F200011000B6D85 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 07A626982B06C6480013FE80 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07A6269F2B06C6480013FE80;
+			remoteInfo = "Outer Spaces";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXNativeTarget section */
+		AABC000C2F20000C000B6D85 /* Outer Spaces Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AABC000D2F20000D000B6D85 /* Build configuration list for PBXNativeTarget "Outer Spaces Tests" */;
+			buildPhases = (
+				AABC00092F200009000B6D85 /* Sources */,
+				AABC00082F200008000B6D85 /* Frameworks */,
+				AABC000B2F20000B000B6D85 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AABC00122F200012000B6D85 /* PBXTargetDependency */,
+			);
+			name = "Outer Spaces Tests";
+			packageProductDependencies = (
+			);
+			productName = "Outer Spaces Tests";
+			productReference = AABC00072F200007000B6D85 /* Outer Spaces Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		07A6269F2B06C6480013FE80 /* Outer Spaces */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 07A626AF2B06C64A0013FE80 /* Build configuration list for PBXNativeTarget "Outer Spaces" */;
@@ -314,6 +376,9 @@
 					07A6269F2B06C6480013FE80 = {
 						CreatedOnToolsVersion = 15.0.1;
 					};
+					AABC000C2F20000C000B6D85 = {
+						CreatedOnToolsVersion = 16.0;
+					};
 				};
 			};
 			buildConfigurationList = 07A6269B2B06C6480013FE80 /* Build configuration list for PBXProject "Outer Spaces" */;
@@ -337,11 +402,19 @@
 			projectRoot = "";
 			targets = (
 				07A6269F2B06C6480013FE80 /* Outer Spaces */,
+				AABC000C2F20000C000B6D85 /* Outer Spaces Tests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		AABC000B2F20000B000B6D85 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		07A6269E2B06C6480013FE80 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -355,6 +428,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		AABC00092F200009000B6D85 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AABC00012F200001000B6D85 /* ModelTests.swift in Sources */,
+				AABC00032F200003000B6D85 /* ManagedDisplaySpacesParserTests.swift in Sources */,
+				AABC00052F200005000B6D85 /* SpaceSwitchCommandTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		07A6269C2B06C6480013FE80 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -367,9 +450,11 @@
 				07C824FC2D933764005C5B48 /* SpaceComponents.swift in Sources */,
 				0742F4A72B1191E500B95465 /* SpacesViewModel.swift in Sources */,
 				07FEE3352B07B2EF00419E50 /* SpaceObserver.swift in Sources */,
+				AABBA0012F100001000B6D85 /* ManagedDisplaySpacesParser.swift in Sources */,
 				07C824FE2D93378B005C5B48 /* Utilities.swift in Sources */,
 				0731007A2B674C9C00F3D630 /* UpdateView.swift in Sources */,
 				07C824F72D9336D9005C5B48 /* Buttons.swift in Sources */,
+				AABBA0032F100003000B6D85 /* SpaceSwitchCommand.swift in Sources */,
 				0705A7912B5241D0005CA574 /* SpaceSwitcher.swift in Sources */,
 				0794FC682B143FC500FD7647 /* SettingsViewModel.swift in Sources */,
 				0764C1052D90F1B5000B6D85 /* PermissionHandler.swift in Sources */,
@@ -391,7 +476,63 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		AABC00122F200012000B6D85 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 07A6269F2B06C6480013FE80 /* Outer Spaces */;
+			targetProxy = AABC00112F200011000B6D85 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		AABC000E2F20000E000B6D85 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = D8A3VX836S;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Test bundle does not send Apple Events.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.lospi.Outer-Spaces.Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Outer Spaces.app/Contents/MacOS/Outer Spaces";
+				TEST_TARGET_NAME = "Outer Spaces";
+			};
+			name = Debug;
+		};
+		AABC000F2F20000F000B6D85 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = D8A3VX836S;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Test bundle does not send Apple Events.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.lospi.Outer-Spaces.Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Outer Spaces.app/Contents/MacOS/Outer Spaces";
+				TEST_TARGET_NAME = "Outer Spaces";
+			};
+			name = Release;
+		};
 		07A626AD2B06C64A0013FE80 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -610,6 +751,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		AABC000D2F20000D000B6D85 /* Build configuration list for PBXNativeTarget "Outer Spaces Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AABC000E2F20000E000B6D85 /* Debug */,
+				AABC000F2F20000F000B6D85 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		07A6269B2B06C6480013FE80 /* Build configuration list for PBXProject "Outer Spaces" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Outer Spaces.xcodeproj/xcshareddata/xcschemes/Outer Spaces.xcscheme
+++ b/Outer Spaces.xcodeproj/xcshareddata/xcschemes/Outer Spaces.xcscheme
@@ -8,6 +8,20 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AABC000C2F20000C000B6D85"
+               BuildableName = "Outer Spaces Tests.xctest"
+               BlueprintName = "Outer Spaces Tests"
+               ReferencedContainer = "container:Outer Spaces.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -28,6 +42,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AABC000C2F20000C000B6D85"
+               BuildableName = "Outer Spaces Tests.xctest"
+               BlueprintName = "Outer Spaces Tests"
+               ReferencedContainer = "container:Outer Spaces.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Outer Spaces/System/Helper/SpaceSwitchCommand.swift
+++ b/Outer Spaces/System/Helper/SpaceSwitchCommand.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct SpaceSwitchCommand: Equatable {
+    let keyCode: Int
+    let usesOptionKey: Bool
+
+    var appleScriptSource: String {
+        if usesOptionKey {
+            return """
+            tell application "System Events"
+                key code \(keyCode) using {control down, option down}
+            end tell
+            """
+        }
+
+        return """
+        tell application "System Events"
+            key code \(keyCode) using {control down}
+        end tell
+        """
+    }
+}
+
+enum SpaceSwitchCommandFactory {
+    private static let keyCodeByDigit: [Int: Int] = [
+        0: 29, 1: 18, 2: 19, 3: 20, 4: 21,
+        5: 23, 6: 22, 7: 26, 8: 28, 9: 25
+    ]
+
+    static func command(forSpaceIndex spaceIndex: Int) throws -> SpaceSwitchCommand {
+        guard spaceIndex >= 0,
+              let keyCode = keyCodeByDigit[(spaceIndex + 1) % 10]
+        else {
+            throw SpaceSwitchError.invalidSpaceIndex
+        }
+
+        return SpaceSwitchCommand(
+            keyCode: keyCode,
+            usesOptionKey: spaceIndex >= 9
+        )
+    }
+}

--- a/Outer Spaces/System/Helper/SpaceSwitcher.swift
+++ b/Outer Spaces/System/Helper/SpaceSwitcher.swift
@@ -18,24 +18,13 @@ enum SpaceSwitchError: Error, LocalizedError {
 }
 
 enum SpaceSwitcher {
-    // Maps (spaceIndex + 1) % 10 → macOS key code for that digit key
-    private static let keycodeDictionary: [Int: Int] = [
-        0: 29, 1: 18, 2: 19, 3: 20, 4: 21,
-        5: 23, 6: 22, 7: 26, 8: 28, 9: 25
-    ]
-
     /// Switches a space using Control+N keyboard simulation via System Events.
     /// This goes through the standard macOS Mission Control transition, giving proper animations.
     /// Spaces 0–8 use Control+1…9; spaces 9–18 use Control+Option+1…9.
     static func switchToSpace(_ space: Space) throws {
         let index = space.spaceIndex
-        guard let keycode = keycodeDictionary[(index + 1) % 10] else {
-            Logger.shared.logError("No key code for spaceIndex \(index)")
-            throw SpaceSwitchError.invalidSpaceIndex
-        }
-
-        let useOptionKey = index >= 9
-        let script = makeSpaceSwitchScript(keycode: keycode, useOptionKey: useOptionKey)
+        let command = try SpaceSwitchCommandFactory.command(forSpaceIndex: index)
+        let script = command.appleScriptSource
 
         var error: NSDictionary?
         guard let appleScript = NSAppleScript(source: script) else {
@@ -51,22 +40,6 @@ enum SpaceSwitcher {
         }
 
         Logger.shared.logInfo("Switched to spaceIndex \(index) on display \(space.displayID)")
-    }
-
-    private static func makeSpaceSwitchScript(keycode: Int, useOptionKey: Bool) -> String {
-        if useOptionKey {
-            return """
-            tell application "System Events"
-                key code \(keycode) using {control down, option down}
-            end tell
-            """
-        } else {
-            return """
-            tell application "System Events"
-                key code \(keycode) using {control down}
-            end tell
-            """
-        }
     }
 
     /// Applies a full preset — switches one space per display, handles Stage Manager.

--- a/Outer Spaces/System/ManagedDisplaySpacesParser.swift
+++ b/Outer Spaces/System/ManagedDisplaySpacesParser.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+struct ManagedDisplaySpacesSnapshot {
+    var desktopSpaces: [DesktopSpaces]
+    var allSpaces: [Space]
+    var activeSpaceID: String?
+}
+
+enum ManagedDisplaySpacesParser {
+    static func parse(_ displays: [NSDictionary]) -> ManagedDisplaySpacesSnapshot {
+        var allSpacesList: [Space] = []
+        var desktopSpacesList: [DesktopSpaces] = []
+        var mainDisplayActiveSpaceID: String?
+
+        for (displayIndex, display) in displays.enumerated() {
+            guard let currentSpace = display["Current Space"] as? [String: Any],
+                  let displaySpaces = display["Spaces"] as? [[String: Any]],
+                  let displayID = display["Display Identifier"] as? String,
+                  let activeSpaceID = currentSpace["ManagedSpaceID"] as? Int
+            else {
+                continue
+            }
+
+            if displayIndex == 0 {
+                mainDisplayActiveSpaceID = String(activeSpaceID)
+            }
+
+            var spacesForDisplay: [Space] = []
+            var regularSpaceIndex = 0
+
+            for spaceInfo in displaySpaces {
+                guard let type = spaceInfo["type"] as? Int, type == 0,
+                      let spaceID = spaceInfo["ManagedSpaceID"] as? Int
+                else {
+                    continue
+                }
+
+                let space = Space(
+                    displayID: displayID,
+                    displayIndex: displayIndex + 1,
+                    spaceID: String(spaceID),
+                    spaceIndex: regularSpaceIndex,
+                    isActive: spaceID == activeSpaceID
+                )
+                regularSpaceIndex += 1
+
+                spacesForDisplay.append(space)
+                allSpacesList.append(space)
+            }
+
+            desktopSpacesList.append(
+                DesktopSpaces(
+                    displayID: displayID,
+                    displayIndex: displayIndex + 1,
+                    spaces: spacesForDisplay
+                )
+            )
+        }
+
+        return ManagedDisplaySpacesSnapshot(
+            desktopSpaces: desktopSpacesList,
+            allSpaces: allSpacesList,
+            activeSpaceID: mainDisplayActiveSpaceID
+        )
+    }
+}

--- a/Outer Spaces/System/SpaceObserver.swift
+++ b/Outer Spaces/System/SpaceObserver.swift
@@ -38,73 +38,15 @@ class SpaceObserver: ObservableObject {
         
         do {
             let displays = try fetchDisplaySpaces()
-            
-            // Process the displays
-            var allSpacesList: [Space] = []
-            var desktopSpacesList: [DesktopSpaces] = []
-            
-            // Process each display and its spaces
-            for (displayIndex, display) in displays.enumerated() {
-                guard let currentSpaces = display["Current Space"] as? [String: Any],
-                      let spaces = display["Spaces"] as? [[String: Any]],
-                      let displayID = display["Display Identifier"] as? String
-                else {
-                    continue
-                }
-                
-                // Get the active space for this display
-                guard let activeSpaceID = currentSpaces["ManagedSpaceID"] as? Int else {
-                    continue
-                }
-                
-                // If this is the main display, save the active space ID
-                if displayIndex == 0 {
-                    self.activeSpaceID = String(activeSpaceID)
-                }
-                
-                // Process all spaces for this display
-                var spacesForDisplay: [Space] = []
-                var regularSpaceIndex = 0
+            let snapshot = ManagedDisplaySpacesParser.parse(displays)
 
-                for spaceInfo in spaces {
-                    // Skip spaces that aren't regular desktop spaces (like fullscreen apps)
-                    guard let type = spaceInfo["type"] as? Int, type == 0,
-                          let spaceID = spaceInfo["ManagedSpaceID"] as? Int
-                    else {
-                        continue
-                    }
-
-                    // Create the space object with display-specific indexing
-                    let space = Space(
-                        displayID: displayID,
-                        displayIndex: displayIndex + 1, // 1-based for UI
-                        spaceID: String(spaceID),
-                        spaceIndex: regularSpaceIndex,
-                        isActive: spaceID == activeSpaceID
-                    )
-                    regularSpaceIndex += 1
-                    
-                    spacesForDisplay.append(space)
-                    allSpacesList.append(space)
-                }
-                
-                // Create the desktop spaces container for this display
-                let desktopSpace = DesktopSpaces(
-                    displayID: displayID,
-                    displayIndex: displayIndex + 1, // 1-based for UI
-                    spaces: spacesForDisplay
-                )
-                
-                desktopSpacesList.append(desktopSpace)
-            }
-            
-            // Update the published properties
-            allSpaces = allSpacesList
-            spaces = desktopSpacesList
+            allSpaces = snapshot.allSpaces
+            spaces = snapshot.desktopSpaces
+            activeSpaceID = snapshot.activeSpaceID
             
             // Log for debugging
-            logger.logInfo("Updated spaces: \(desktopSpacesList.count) displays, \(allSpacesList.count) total spaces")
-            for (i, display) in desktopSpacesList.enumerated() {
+            logger.logInfo("Updated spaces: \(spaces.count) displays, \(allSpaces.count) total spaces")
+            for (i, display) in spaces.enumerated() {
                 logger.logInfo("Display \(i + 1) (\(display.displayID)): \(display.desktopSpaces.count) spaces")
                 for space in display.desktopSpaces {
                     logger.logInfo("  - \(space.debugDescription)")


### PR DESCRIPTION
## Summary
- add the first Swift Testing unit-test target for core model and extracted helper coverage
- extract managed-display space parsing into a pure parser
- extract space-switch AppleScript command construction into a pure helper
- add a GitHub Actions PR Checks workflow for pull requests into `main` and `v2.1.0`

## Validation
- `xcodebuild -project "OuterSpaces/Outer Spaces.xcodeproj" -scheme "Outer Spaces" -configuration Debug -derivedDataPath /private/tmp/OuterSpacesTestsDerivedData -destination "platform=macOS,arch=arm64" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build -quiet`
- `xcodebuild -project "OuterSpaces/Outer Spaces.xcodeproj" -scheme "Outer Spaces" -configuration Debug -derivedDataPath /private/tmp/OuterSpacesTestsDerivedData -destination "platform=macOS,arch=arm64" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO test -quiet`

Notes: live macOS dependencies remain manual QA in this phase: `CGSCopyManagedDisplaySpaces`, `NSAppleScript`, TCC/accessibility APIs, Focus status, and Stage Manager defaults writes.
