### PR TITLE
fix: clean release signing entitlements

### DIFF
--- a/Outer Spaces/Outer_Spaces.entitlements
+++ b/Outer Spaces/Outer_Spaces.entitlements
@@ -2,11 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.usernotifications.communication</key>
-	<true/>
 	<key>com.apple.security.automation.apple-events</key>
-	<true/>
-	<key>com.apple.security.temporary-exception.apple-events</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- remove Communication Notifications entitlement from the macOS app target
- remove invalid App Sandbox temporary Apple Events exception
- keep the hardened-runtime Apple Events entitlement required for AppleScript automation

## Verification
- xcodebuild test: 12 tests passed
- Developer ID archive succeeded with identity D628DCDF730C6162B35E50537FE7CBE8524BA78C
- codesign --verify --deep --strict passed outside the sandbox
- spctl rejects the app only because it is not notarized yet