### PR TITLE
release: update appcast for v2.1.0

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,14 @@
     <channel>
         <title>Outer Spaces</title>
         <item>
+            <title>2.1.0</title>
+            <pubDate>Sun, 24 May 2026 22:55:50 -0300</pubDate>
+            <sparkle:version>14</sparkle:version>
+            <sparkle:shortVersionString>2.1.0</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/Lospi/OuterSpaces/releases/download/v2.1.0/OuterSpaces.dmg" length="3944840" type="application/octet-stream" sparkle:edSignature="MCESLxluFs14Xxf8NSyZbZcMm4CJFMe8iOrcFo5QMtbmSNYmYZQx0KbGpanDjuLPJ3AQt8Wx2ya0IJGrJnCQAg=="/>
+        </item>
+        <item>
             <title>2.0</title>
             <pubDate>Wed, 09 Apr 2025 20:36:29 -0300</pubDate>
             <sparkle:version>13</sparkle:version>


### PR DESCRIPTION
## Summary
- add v2.1.0 build 14 as the top Sparkle appcast item
- point Sparkle to the notarized GitHub Release asset
- include the final EdDSA signature and file length

## Verification
- `xmllint --noout appcast.xml`
- GitHub release asset URL returns HTTP 200
- DMG code signature verifies
- DMG notarization ticket validates
- Gatekeeper accepts the DMG and app inside